### PR TITLE
Calc check

### DIFF
--- a/R/add_dropout_idx.R
+++ b/R/add_dropout_idx.R
@@ -9,18 +9,18 @@
 add_dropout_idx <- function(df, q_pos){
   foo <- df[rev(q_pos)]
   do <- NA
-  for(line in 1:nrow(foo)){
-    if(is.na(foo[line, 1])){ # if there is an NA at col 1 (last question col of original data), probably dropout
-      do[line] <- 1
-      for(col in 2:ncol(foo)){
-        if(is.na(foo[line, col])){
-          do[line] <- do[line] + 1
+  for(li in 1:nrow(foo)){
+    if(is.na(foo[li, 1])){ # if there is an NA at col 1 (last question col of original data), probably dropout
+      do[li] <- 1
+      for(co in 2:ncol(foo)){
+        if(is.na(foo[li, co])){
+          do[li] <- do[li] + 1
         } else {
           next
         }
       }
     } else{
-      do[line] <- 0
+      do[li] <- 0
       next
     }
     # browser()

--- a/R/add_dropout_idx.R
+++ b/R/add_dropout_idx.R
@@ -17,7 +17,22 @@ add_dropout_idx <- function(df, q_pos){
   # # out vector contains drop out position
   # # dpos <-
   # df$do_idx <- sapply(tpos, find_drop_out, clnms = nms)
-  df$do_idx <- length(q_pos) - rowSums(sapply(df[, q_pos], is.na))
+  df$do_idx <- length(q_pos) - rowSums(sapply(df[, q_pos], is.na)) # length(q_pos) - 
+  
+  # identify single missing by using block entropy
+  ent <- NA
+  for(i in 1:nrow(df)){
+    x <- q_pos - which(is.na(df[i, ]))
+    
+    p_xi <- table(x) / length(x)
+    result <- sum(p_xi * log2(p_xi)) * (-1)
+    
+    ent[i] <- result
+  }
+  
+  # df$do_idx[which(ent > 1)] <- 0 # length(q_pos)
+  # df$do_idx[df$do_idx == length(q_pos)] <- 0
+  df$do_idx[which(df$do_idx == length(q_pos) | ent > 1)] <- 0
   
   df
 }

--- a/R/compute_stats.R
+++ b/R/compute_stats.R
@@ -7,16 +7,13 @@
 #'
 #' @import data.table
 #' @export
-compute_stats <- function(df,
-                          by_cond = "None",
-                          no_of_vars
+compute_stats2 <- function(df,
+                           by_cond = "None",
+                           no_of_vars
 ){
-  out <- list()
   dtable <- data.table(df)
   
-  if(by_cond == "None"){
-    out$cond <- NULL
-  } else {
+  if(by_cond %in% names(df)){ # if experimental condition is actually in the data
     # drop out count by conditions
     do_by_cond <- dtable[,list(drop_out_count = .N),
                          keyby = c("do_idx",by_cond)]
@@ -45,9 +42,12 @@ compute_stats <- function(df,
     name_pos <- match(by_cond,names(full_grid))
     names(full_grid)[name_pos] <- "condition"
     full_grid$condition <- factor(full_grid$condition)
-    out$cond <- full_grid[,c("do_idx","condition","cs","N","remain",
+    
+    cond_grid <- full_grid[,c("do_idx","condition","cs","N","remain",
                               "pct_remain"),with = FALSE]
-  } 
+  } else{
+    cond_grid <- NULL
+  }
   
   do_by_total <- dtable[,list(drop_out_count = .N),
                         keyby = c("do_idx")]
@@ -65,9 +65,8 @@ compute_stats <- function(df,
   total_grid[, pct_remain := (N-cs)/N]  
   total_grid[, condition := "total"]
   total_grid$condition <- factor(total_grid$condition)
-  out$total <- total_grid[,c("do_idx","condition","cs","N","remain",
-                             "pct_remain"),with = FALSE]
-  
-  rbind(out$total, out$cond)
-  
+
+  rbind(total_grid[,c("do_idx","condition","cs","N","remain",
+                      "pct_remain"),with = FALSE],
+        cond_grid)
 }

--- a/R/compute_stats.R
+++ b/R/compute_stats.R
@@ -7,7 +7,7 @@
 #'
 #' @import data.table
 #' @export
-compute_stats2 <- function(df,
+compute_stats <- function(df,
                            by_cond = "None",
                            no_of_vars
 ){


### PR DESCRIPTION
Calculation now goes through a horizotnally flipped dataset to count the missings from the end. That way, only sequences at the end where people really stopped are counted and single missings in between in the data are ignored. It now outputs the precise question/page (depending on the data) where people actually dropped out. Checked with example data and some of my data - I hope I caught all issues!